### PR TITLE
Make version configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ In order to use GradleMavenizer you have to add the line
 
 `apply from: 'https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/master/gradle-mavenizer.gradle'`
 
-at the <b>very bottom</b> of the *build.gradle* file.
+at the <b>very bottom</b> of the *build.gradle* file. Alternatively, to use a specific release version, add this property to the project (see Releases at the top of the Github page for released versions):
+
+    mavPluginVersion = '1.0'
+    
+and add this line to the very bottom of the *build.gradle* file:
+
+    apply from: "https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/${project.mavPluginVersion}/gradle-mavenizer.gradle"`
 
 ## <a name="customization"/>Customization
 GradleMavenizer is highly customizable.

--- a/gradle-mavenizer.gradle
+++ b/gradle-mavenizer.gradle
@@ -1,8 +1,10 @@
 apply plugin: 'maven-publish'
 
-apply from: 'https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/master/artifact-javadoc-handler.gradle'
-apply from: 'https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/master/artifact-pom-manager.gradle'
-apply from: 'https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/master/utils.gradle'
+githubCommitIdentifier = project.hasProperty('mavPluginVersion') ? project.mavPluginVersion : 'master'
+
+apply from: "https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/${githubCommitIdentifier}/artifact-javadoc-handler.gradle"
+apply from: "https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/${githubCommitIdentifier}/artifact-pom-manager.gradle"
+apply from: "https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/${githubCommitIdentifier}/utils.gradle"
 
 project.afterEvaluate {
     publishing {


### PR DESCRIPTION
This is my idea for answering #1. My Gradle/Groovy knowledge is rudimentary and I couldn't actually test this since it would have to already be pulled to your repository, so please pardon any syntax mistakes.

It should work if you tag a commit with something like 1.0, so it can be referred to easily. Alternatively, a specific commit can be used instead of a tagged version. Either way works with raw.githubusercontent.com links.