### PR TITLE
Fix: javaCompile is obsolete

### DIFF
--- a/artifact-javadoc-handler.gradle
+++ b/artifact-javadoc-handler.gradle
@@ -9,7 +9,7 @@ if (isAndroidProject()) {
 
         android.libraryVariants.all { variant ->
             if (variant.name == 'release') {
-                owner.classpath += variant.javaCompile.classpath
+                owner.classpath += variant.javaCompileProvider.get().classpath
             }
         }
 


### PR DESCRIPTION
WARNING: API 'variant.getJavaCompile()' is obsolete