### PR TITLE
Publish Kotlin sources in pure Java/Kotlin libraries

### DIFF
--- a/artifact-javadoc-handler.gradle
+++ b/artifact-javadoc-handler.gradle
@@ -38,7 +38,7 @@ if (isAndroidProject()) {
     }
 } else {
     task sourcesJar(type: Jar) {
-        from sourceSets.main.allJava
+        from sourceSets.main.allSource
         archiveClassifier = 'sources'
     }
 


### PR DESCRIPTION
As described in issue #32, Kotlin source files are not published for non-Android libraries.

Made a simple change to the sources-generating task specific to non-Android projects, as described [in this SO post](https://stackoverflow.com/questions/11474729/how-to-build-sources-jar-with-gradle/11475089).

Tested in a private project, and sources are published correctly.