### PR TITLE
Trying the compile configuration if possible

### DIFF
--- a/artifact-pom-manager.gradle
+++ b/artifact-pom-manager.gradle
@@ -82,12 +82,20 @@ def addDependencyNode(dependenciesNode, dep, scope, classifier, extension) {
     }
 }
 
-def manageConfigurations(configurations) {
-    configurations.compile.getDependencies().each { dep -> addDependency(dep, "compile") }
-    configurations.api.getDependencies().each { dep -> addDependency(dep, "compile") }
+def manageConfigurations(configurations) {  
+    try {
+        configurations.compile.getDependencies().each { dep -> addDependency(dep, "compile") }
+        configurations.api.getDependencies().each { dep -> addDependency(dep, "compile") }
+    } catch(Exception e){
+        configurations.api.getDependencies().each { dep -> addDependency(dep, "implementation") }
+    }
+    
     configurations.implementation.getDependencies().each { dep -> addDependency(dep, "runtime") }
     configurations.testImplementation.getDependencies().each { dep -> addDependency(dep, "test") }
-    configurations.testCompile.getDependencies().each { dep -> addDependency(dep, "test") }
+
+    try {
+        configurations.testCompile.getDependencies().each { dep -> addDependency(dep, "test") }
+    } catch(Exception e){}
 
     if (!isAndroidProject()) {
         configurations.runtime.getDependencies().each { dep -> addDependency(dep, "runtime") }


### PR DESCRIPTION
This performs a try/catch to try to maintain backwards compatibility.

Another solution would be could ditching backwards compatibility and just remove the 'compile' and 'testCompile' lines then replace:
`configurations.api.getDependencies().each { dep -> addDependency(dep, "compile") }`

with:
`configurations.api.getDependencies().each { dep -> addDependency(dep, "implementation") }`